### PR TITLE
Fixed socat, updated Docker support, and clarified example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.9.2
 
 RUN apk add --no-cache openssl socat
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Run the `build.sh` script, tested on Kali Linux. Alternatively, build the docker
 
 Installation using the `build.sh` script on Kali Linux will provide a new `socat23` command to use. For the docker image, example invocation would be:
 
+Window 1
 ```bash
 docker run --rm -p 50000:80 socat23:latest socat -v -ls tcp4-listen:80,fork,reuseaddr ssl:www.google.com:443,verify=0
+```
+
+Window 2
+```bash
+curl http://localhost:80/ --header "Host: www.google.com"
 ```

--- a/README.md
+++ b/README.md
@@ -19,5 +19,5 @@ docker run --rm -p 50000:80 socat23:latest socat -v -ls tcp4-listen:80,fork,reus
 
 Window 2
 ```bash
-curl http://localhost:80/ --header "Host: www.google.com"
+curl http://localhost:50000/ -H "Host: www.google.com"
 ```

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ set -e
 # https://en.wikipedia.org/wiki/OpenSSL
 #   sslv2 is ripped from 1.1.0 so build latest 1.0.2
 opensslversion=1.0.2m
-socatversion=1.7.3.2
+socatversion=1.7.3.4
 working_directory=/usr/local/src
 
 # OpenSSL first


### PR DESCRIPTION
`README.md` - Made the example easier to follow
`build.sh` - Slightly updated the version of socat as the previous version had been removed from dest-unreach.org
`Dockerfile` - Updated the version of Alpine to support `linux/arm64/v8`